### PR TITLE
Fixed Semantic Version in Module Name

### DIFF
--- a/audio_classification_test.go
+++ b/audio_classification_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 func TestAudioClassificationRequest(t *testing.T) {

--- a/conversational_test.go
+++ b/conversational_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/examples/audio_classification/main.go
+++ b/examples/audio_classification/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/conversational/main.go
+++ b/examples/conversational/main.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/fill_mask/main.go
+++ b/examples/fill_mask/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/image_classification/main.go
+++ b/examples/image_classification/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/image_segmentation/main.go
+++ b/examples/image_segmentation/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/basicfont"
 	"golang.org/x/image/math/fixed"

--- a/examples/image_to_text/main.go
+++ b/examples/image_to_text/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/object_detection/main.go
+++ b/examples/object_detection/main.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/question_answering/main.go
+++ b/examples/question_answering/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/sentence_similarity/main.go
+++ b/examples/sentence_similarity/main.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/speech_recognition/main.go
+++ b/examples/speech_recognition/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/summarization/main.go
+++ b/examples/summarization/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/table_question_answering/main.go
+++ b/examples/table_question_answering/main.go
@@ -6,7 +6,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const TableRows = 2

--- a/examples/text_classification/main.go
+++ b/examples/text_classification/main.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/text_generation/main.go
+++ b/examples/text_generation/main.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/text_to_image/main.go
+++ b/examples/text_to_image/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/token_classification/main.go
+++ b/examples/token_classification/main.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/translation/main.go
+++ b/examples/translation/main.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/examples/zeroshot/main.go
+++ b/examples/zeroshot/main.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/fill_mask_test.go
+++ b/fill_mask_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Kardbord/hfapigo
+module github.com/Kardbord/hfapigo/v2
 
 go 1.17
 

--- a/image_classification_test.go
+++ b/image_classification_test.go
@@ -3,7 +3,7 @@ package hfapigo_test
 import (
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 func TestImageClassificationRequest(t *testing.T) {

--- a/image_segmentation_test.go
+++ b/image_segmentation_test.go
@@ -3,7 +3,7 @@ package hfapigo_test
 import (
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 func TestImageSegmentationRequest(t *testing.T) {

--- a/image_to_text_test.go
+++ b/image_to_text_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 func TestImageToText(t *testing.T) {

--- a/object_detection_test.go
+++ b/object_detection_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 func TestObjectDetectionRequest(t *testing.T) {

--- a/question_answering_test.go
+++ b/question_answering_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/sentence_similarity_test.go
+++ b/sentence_similarity_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 const HuggingFaceTokenEnv = "HUGGING_FACE_TOKEN"

--- a/speech_recognition_test.go
+++ b/speech_recognition_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 func TestSpeechRecognitionRequest(t *testing.T) {

--- a/summarization_test.go
+++ b/summarization_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/table_question_answering_test.go
+++ b/table_question_answering_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/text_classification_test.go
+++ b/text_classification_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/text_generation_test.go
+++ b/text_generation_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/text_to_image_test.go
+++ b/text_to_image_test.go
@@ -3,7 +3,7 @@ package hfapigo_test
 import (
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 )
 
 func TestTextToImage(t *testing.T) {

--- a/token_classification_test.go
+++ b/token_classification_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/translation_test.go
+++ b/translation_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/zeroshot_classification_test.go
+++ b/zeroshot_classification_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Kardbord/hfapigo"
+	"github.com/Kardbord/hfapigo/v2"
 	"github.com/google/go-cmp/cmp"
 )
 


### PR DESCRIPTION
When I updated this module to v2.0.0, I did not realize that I was not following proper conventions for Go module revisions, and therefore v2.0.0 was not usable. This PR aims to fix that.