### PR TITLE
General Maintenance + Deprecate Conversational Endpoint (for now)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Vet
+        run: go vet -v ./...
+
       - name: Test
         run: go test -timeout 300s -v ./...
         env:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An API key is required for authorized access. To get one, create a [Hugging Face
 See the [examples](./examples) directory.
 
 - [Audio Classification](./examples/audio_classification/main.go)
-- [Conversational](./examples/conversational/main.go)
+- ~~[Conversational](./examples/conversational/main.go)~~
 - [Fill Mask](./examples/fill_mask/main.go)
 - [Image Classification](./examples/image_classification/main.go)
 - [Image Segmentation](./examples/image_segmentation/main.go)

--- a/conversational.go
+++ b/conversational.go
@@ -109,6 +109,10 @@ type Conversation struct {
 	PastUserInputs []string `json:"past_user_inputs,omitempty"`
 }
 
+// Deprecated: HF's conversational endpoint seems to be under construction
+// and slated to be either updated or replaced.
+// TODO: Update or remove conversational support once it becomes
+// clear what its replacement is.
 func SendConversationalRequest(model string, request *ConversationalRequest) (*ConversationalResponse, error) {
 	if request == nil {
 		return nil, errors.New("nil ConversationalRequest")

--- a/conversational_test.go
+++ b/conversational_test.go
@@ -65,6 +65,8 @@ func TestMarshalUnMarshalConversationalRequest(t *testing.T) {
 }
 
 func TestConversationalRequest(t *testing.T) {
+	t.Skip("The conversational endpoint seems to be undergoing deprecation/refactor. Disabling the unit tests for it until more information is available and updates can be made.")
+
 	// Basic request
 	{
 		cresp, err := hfapigo.SendConversationalRequest(hfapigo.RecommendedConversationalModel, &hfapigo.ConversationalRequest{

--- a/examples/conversational/main.go
+++ b/examples/conversational/main.go
@@ -32,6 +32,10 @@ func init() {
 
 const model = "facebook/blenderbot-400M-distill"
 
+// Deprecated: HF's conversational endpoint seems to be under construction
+// and slated to be either updated or replaced.
+// TODO: Update or remove conversational support once it becomes
+// clear what its replacement is.
 func main() {
 	fmt.Println("Enter your messages below. Hit enter to send. Use Ctrl+c or Ctrl+d to quit.")
 

--- a/examples/conversational/main.go
+++ b/examples/conversational/main.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func init() {
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-ch

--- a/image_segmentation.go
+++ b/image_segmentation.go
@@ -2,7 +2,7 @@ package hfapigo
 
 import "encoding/json"
 
-const RecommendedImageSegmentationModel = "facebook/detr-resnet-50-panoptic"
+const RecommendedImageSegmentationModel = "nvidia/segformer-b1-finetuned-cityscapes-1024-1024"
 
 type ImageSegmentationResponse struct {
 	// The label for the class (model specific) of a segment.

--- a/tools/build-examples.sh
+++ b/tools/build-examples.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+pushd "$(dirname "${BASH_SOURCE[0]}")/../examples" >/dev/null
+
+for d in */; do
+  pushd "${d}" >/dev/null
+  echo "Building ${d}"
+  go build
+  popd >/dev/null
+done

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
+
+echo "Formatting code..."
+go fmt ./...
+echo "Building $(basename "$(pwd)")"
+go build ./...
+echo "Vetting..."
+go vet ./...
+echo "Running tests..."
+go test ./...
+echo "Done."

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
+./build-examples.sh
+
+pushd .. >/dev/null
 echo "Formatting code..."
 go fmt ./...
 echo "Building $(basename "$(pwd)")"


### PR DESCRIPTION
This PR mainly contains maintenance updates. The biggest change is the (hopefully temporary) deprecation of the conversational endpoint. HF's conversational endpoint seems to be under construction and slated to be either updated or replaced. See huggingface/huggingface.js#457. Until it becomes clear what updates are needed, the conversational endpoint will remain broken and marked as deprecated.