### PR TITLE
September '24 Maintenance

### DIFF
--- a/audio_classification_test.go
+++ b/audio_classification_test.go
@@ -2,24 +2,14 @@ package hfapigo_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/Kardbord/hfapigo/v3"
 )
 
 func TestAudioClassificationRequest(t *testing.T) {
-	const retries = 10
-
 	acResps := []*hfapigo.AudioClassificationResponse{}
 	var err error
-	for i := 0; i < retries; i++ {
-		acResps, err = hfapigo.SendAudioClassificationRequest(hfapigo.RecommendedAudioClassificationModel, TestFilesDir+"/sample.flac")
-		if err == nil {
-			break
-		} else {
-			time.Sleep(time.Second * 5)
-		}
-	}
+	acResps, err = hfapigo.SendAudioClassificationRequest(hfapigo.RecommendedAudioClassificationModel, TestFilesDir+"/sample.flac")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/image_to_text_test.go
+++ b/image_to_text_test.go
@@ -2,25 +2,15 @@ package hfapigo_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/Kardbord/hfapigo/v3"
 )
 
 func TestImageToText(t *testing.T) {
-	const retries = 10
 
 	resps := []*hfapigo.ImageToTextResponse{}
 	var err error
-	for i := 0; i < retries; i++ {
-		resps, err = hfapigo.SendImageToTextRequest(hfapigo.RecommendedImageToTextModel, TestFilesDir+"/test-image.png")
-		if err == nil {
-			break
-		} else {
-			time.Sleep(time.Second * 5)
-		}
-	}
-
+	resps, err = hfapigo.SendImageToTextRequest(hfapigo.RecommendedImageToTextModel, TestFilesDir+"/test-image.png")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/object_detection_test.go
+++ b/object_detection_test.go
@@ -2,24 +2,14 @@ package hfapigo_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/Kardbord/hfapigo/v3"
 )
 
 func TestObjectDetectionRequest(t *testing.T) {
-	const retries = 10
-
 	resps := []*hfapigo.ObjectDetectionResponse{}
 	var err error
-	for i := 0; i < retries; i++ {
-		resps, err = hfapigo.SendObjectDetectionRequest(hfapigo.RecommendedObjectDetectionModel, TestFilesDir+"/test-image.png")
-		if err == nil {
-			break
-		} else {
-			time.Sleep(time.Second * 5)
-		}
-	}
+	resps, err = hfapigo.SendObjectDetectionRequest(hfapigo.RecommendedObjectDetectionModel, TestFilesDir+"/test-image.png")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -20,12 +20,9 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
-	shouldWarn := hfapigo.APIKey() == ""
-	if shouldWarn {
-		fmt.Printf("%s not found in env, tests may fail due to rate limiting.\n", HuggingFaceTokenEnv)
+	if hfapigo.APIKey() == "" {
+		fmt.Fprintf(os.Stderr, "%s not set, tests will fail due to rate limiting.", HuggingFaceTokenEnv)
+		os.Exit(1)
 	}
 	m.Run()
-	if shouldWarn {
-		fmt.Printf("%s not found in env, tests may fail due to rate limiting.\n", HuggingFaceTokenEnv)
-	}
 }

--- a/speech_recognition_test.go
+++ b/speech_recognition_test.go
@@ -2,24 +2,14 @@ package hfapigo_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/Kardbord/hfapigo/v3"
 )
 
 func TestSpeechRecognitionRequest(t *testing.T) {
-	const retries = 10
-
 	arResp := &hfapigo.SpeechRecognitionResponse{}
 	var err error
-	for i := 0; i < retries; i++ {
-		arResp, err = hfapigo.SendSpeechRecognitionRequest(hfapigo.RecommendedSpeechRecongnitionModelEnglish, TestFilesDir+"/sample.flac")
-		if err == nil {
-			break
-		} else {
-			time.Sleep(time.Second * 5)
-		}
-	}
+	arResp, err = hfapigo.SendSpeechRecognitionRequest(hfapigo.RecommendedSpeechRecongnitionModelEnglish, TestFilesDir+"/sample.flac")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/text_to_image.go
+++ b/text_to_image.go
@@ -10,7 +10,7 @@ import (
 	_ "image/png"
 )
 
-const RecommendedTextToImageModel = "runwayml/stable-diffusion-v1-5"
+const RecommendedTextToImageModel = "stable-diffusion-v1-5/stable-diffusion-v1-5"
 
 // Request structure for text-to-image model
 type TextToImageRequest struct {


### PR DESCRIPTION
- Fail unit tests early if no API key is present
- Updated text-to-image model to a mirror of the old model.
    - [Runwayml](https://huggingface.co/runwayml) no longer maintains a presence on huggingface, but there are forks of their old models created by other users.
- Removed retries in unit tests that were causing rate limit issues